### PR TITLE
Bug Fix : Transparent background for Clock icons

### DIFF
--- a/iconloaderlib/src/com/android/launcher3/icons/ClockDrawableWrapper.java
+++ b/iconloaderlib/src/com/android/launcher3/icons/ClockDrawableWrapper.java
@@ -334,7 +334,7 @@ public class ClockDrawableWrapper extends CustomAdaptiveIconDrawable implements 
                 if (wrapper != null) {
                     int[] colors = getColors(context);
                     ColorFilter bgFilter = new PorterDuffColorFilter(colors[0], Mode.SRC_ATOP);
-                    if(!IconPreferencesKt.shouldTransparentBGIcons(context)){
+                    if(IconPreferencesKt.shouldTransparentBGIcons(context)){
                         mFlattenedBackground.eraseColor(Color.TRANSPARENT);
                     }
                     return new ClockBitmapInfo(icon, colors[1], scale,


### PR DESCRIPTION
Background has to be removed if Transparanet background enable , it's doing opposite now.

Follow up #7.
