### PR TITLE
Add Support Gesture for A13

### DIFF
--- a/iconloaderlib/src/com/android/launcher3/icons/BaseIconFactory.java
+++ b/iconloaderlib/src/com/android/launcher3/icons/BaseIconFactory.java
@@ -3,9 +3,15 @@ package com.android.launcher3.icons;
 import static android.graphics.Paint.DITHER_FLAG;
 import static android.graphics.Paint.FILTER_BITMAP_FLAG;
 
+import static com.android.launcher3.icons.BitmapInfo.FLAG_INSTANT;
+import static com.android.launcher3.icons.BitmapInfo.FLAG_WORK;
 import static com.android.launcher3.icons.IconProvider.ICON_TYPE_DEFAULT;
 import static com.android.launcher3.icons.ShadowGenerator.BLUR_FACTOR;
 
+import static app.lawnchair.icons.CustomAdaptiveIconDrawable.getExtraInsetFraction;
+
+import android.annotation.SuppressLint;
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -25,10 +31,13 @@ import android.graphics.drawable.InsetDrawable;
 import android.os.Build;
 import android.os.Process;
 import android.os.UserHandle;
+import android.util.SparseBooleanArray;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.android.launcher3.icons.BitmapInfo.Extender;
+import com.android.launcher3.util.FlagOp;
 
 import app.lawnchair.icons.CustomAdaptiveIconDrawable;
 import app.lawnchair.icons.ExtendedBitmapDrawable;
@@ -65,6 +74,15 @@ public class BaseIconFactory implements AutoCloseable {
     private Drawable mWrapperIcon;
     private int mWrapperBackgroundColor = DEFAULT_WRAPPER_BACKGROUND;
     private Bitmap mUserBadgeBitmap;
+
+
+    // Shadow bitmap used as background for theme icons
+    private Bitmap mWhiteShadowLayer;
+
+    private final SparseBooleanArray mIsUserBadged = new SparseBooleanArray ();
+
+
+    protected boolean mMonoIconEnabled;
 
     private final Paint mTextPaint = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
     private static final float PLACEHOLDER_TEXT_SIZE = 20f;
@@ -433,6 +451,162 @@ public class BaseIconFactory implements AutoCloseable {
                 user, Build.VERSION.SDK_INT);
     }
 
+    private Bitmap createIconBitmap(@NonNull Drawable icon, float scale, int size,
+                                    Bitmap.Config config) {
+        Bitmap bitmap = Bitmap.createBitmap(size, size, config);
+        if (icon == null) {
+            return bitmap;
+        }
+        mCanvas.setBitmap(bitmap);
+        mOldBounds.set(icon.getBounds());
+
+        if (icon instanceof AdaptiveIconDrawable) {
+            int offset = Math.max((int) Math.ceil(BLUR_FACTOR * size),
+                Math.round(size * (1 - scale) / 2 ));
+            // b/211896569: AdaptiveIconDrawable do not work properly for non top-left bounds
+            icon.setBounds(0, 0, size - offset - offset, size - offset - offset);
+            int count = mCanvas.save();
+            mCanvas.translate(offset, offset);
+
+            if (icon instanceof BitmapInfo.Extender) {
+                ((Extender) icon).drawForPersistence(mCanvas);
+            } else {
+                icon.draw(mCanvas);
+            }
+            mCanvas.restoreToCount(count);
+        } else {
+            if (icon instanceof BitmapDrawable) {
+                BitmapDrawable bitmapDrawable = (BitmapDrawable) icon;
+                Bitmap b = bitmapDrawable.getBitmap();
+                if (bitmap != null && b.getDensity() == Bitmap.DENSITY_NONE) {
+                    bitmapDrawable.setTargetDensity(mContext.getResources().getDisplayMetrics());
+                }
+            }
+            int width = size;
+            int height = size;
+
+            int intrinsicWidth = icon.getIntrinsicWidth();
+            int intrinsicHeight = icon.getIntrinsicHeight();
+            if (intrinsicWidth > 0 && intrinsicHeight > 0) {
+                // Scale the icon proportionally to the icon dimensions
+                final float ratio = (float) intrinsicWidth / intrinsicHeight;
+                if (intrinsicWidth > intrinsicHeight) {
+                    height = (int) (width / ratio);
+                } else if (intrinsicHeight > intrinsicWidth) {
+                    width = (int) (height * ratio);
+                }
+            }
+            final int left = (size - width) / 2;
+            final int top = (size - height) / 2;
+            icon.setBounds(left, top, left + width, top + height);
+            mCanvas.save();
+            mCanvas.scale(scale, scale, size / 2, size / 2);
+            icon.draw(mCanvas);
+            mCanvas.restore();
+
+        }
+        icon.setBounds(mOldBounds);
+        mCanvas.setBitmap(null);
+        return bitmap;
+    }
+
+    /**
+     * Creates bitmap using the source drawable and various parameters.
+     * The bitmap is visually normalized with other icons and has enough spacing to add shadow.
+     *
+     * @param icon                      source of the icon
+     * @return a bitmap suitable for disaplaying as an icon at various system UIs.
+     */
+    @SuppressLint("UnsafeOptInUsageError")
+    public BitmapInfo createBadgedIconBitmap(@NonNull Drawable icon,
+                                             @Nullable IconOptions options) {
+        boolean shrinkNonAdaptiveIcons = options == null || options.mShrinkNonAdaptiveIcons;
+        float[] scale = new float[1];
+        icon = normalizeAndWrapToAdaptiveIcon(icon, shrinkNonAdaptiveIcons, null, scale);
+        Bitmap bitmap = createIconBitmap(icon, scale[0]);
+        if (icon instanceof AdaptiveIconDrawable) {
+            mCanvas.setBitmap(bitmap);
+            getShadowGenerator().recreateIcon(Bitmap.createBitmap(bitmap), mCanvas);
+            mCanvas.setBitmap(null);
+        }
+
+        int color = extractColor(bitmap);
+        BitmapInfo info = BitmapInfo.of(bitmap, color);
+
+        if (icon instanceof BitmapInfo.Extender) {
+            info = ((BitmapInfo.Extender) icon).getExtendedInfo(bitmap, color, this, scale[0]);
+        } else if (mMonoIconEnabled && IconProvider.ATLEAST_T
+            && icon instanceof AdaptiveIconDrawable) {
+//            Drawable mono = ((AdaptiveIconDrawable) icon).getMonochrome();
+//            if (mono != null) {
+//                // Convert mono drawable to bitmap
+//                Drawable paddedMono = new ClippedMonoDrawable(mono);
+//                info.setMonoIcon(
+//                    createIconBitmap(paddedMono, scale[0], mIconBitmapSize, Bitmap.Config.ALPHA_8),
+//                    this);
+//            }
+        }
+        info = info.withFlags(getBitmapFlagOp(options));
+        return info;
+    }
+
+    public FlagOp getBitmapFlagOp(@Nullable IconOptions options) {
+        FlagOp op = FlagOp.NO_OP;
+        if (options != null) {
+            if (options.mIsInstantApp) {
+                op = FlagOp.addFlag(FLAG_INSTANT);
+            }
+
+            if (options.mUserHandle != null) {
+                int key = options.mUserHandle.hashCode();
+                boolean isBadged;
+                int index;
+                if ((index = mIsUserBadged.indexOfKey(key)) >= 0) {
+                    isBadged = mIsUserBadged.valueAt(index);
+                } else {
+                    // Check packageManager if the provided user needs a badge
+                    NoopDrawable d = new NoopDrawable();
+                    isBadged = (d != mPm.getUserBadgedIcon(d, options.mUserHandle));
+                    mIsUserBadged.put(key, isBadged);
+                }
+                op = op.setFlag(FLAG_WORK, isBadged);
+            }
+        }
+        return op;
+    }
+
+    /** package private */
+    Bitmap getWhiteShadowLayer() {
+        if (mWhiteShadowLayer == null) {
+            mWhiteShadowLayer = createScaledBitmapWithShadow(
+                new AdaptiveIconDrawable(new ColorDrawable(Color.WHITE), null));
+        }
+        return mWhiteShadowLayer;
+    }
+
+    public BitmapInfo makeDefaultIcon() {
+        return createBadgedIconBitmap(getFullResDefaultActivityIcon2(mFillResIconDpi));
+    }
+
+    public BitmapInfo createBadgedIconBitmap(@NonNull Drawable icon) {
+        return createBadgedIconBitmap(icon, null);
+    }
+
+    public static Drawable getFullResDefaultActivityIcon2(int iconDpi) {
+        return Resources.getSystem().getDrawableForDensity(
+            android.R.drawable.sym_def_app_icon, iconDpi);
+    }
+
+    /** package private */
+    public Bitmap createScaledBitmapWithShadow(Drawable d) {
+        float scale = getNormalizer().getScale(d, null, null, null);
+        Bitmap bitmap = createIconBitmap(d, scale);
+        mCanvas.setBitmap(bitmap);
+        getShadowGenerator().recreateIcon(Bitmap.createBitmap(bitmap), mCanvas);
+        mCanvas.setBitmap(null);
+        return bitmap;
+    }
+
     public static Drawable getFullResDefaultActivityIcon(int iconDpi) {
         Drawable icon = Resources.getSystem().getDrawableForDensity(
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.O
@@ -463,6 +637,37 @@ public class BaseIconFactory implements AutoCloseable {
         return (int) (ICON_BADGE_SCALE * iconSize);
     }
 
+    public static class IconOptions {
+
+        boolean mShrinkNonAdaptiveIcons = true;
+        boolean mIsInstantApp;
+        UserHandle mUserHandle;
+
+        /**
+         * Set to false if non-adaptive icons should not be treated
+         */
+        public IconOptions setShrinkNonAdaptiveIcons(boolean shrink) {
+            mShrinkNonAdaptiveIcons = shrink;
+            return this;
+        }
+
+        /**
+         * User for this icon, in case of badging
+         */
+        public IconOptions setUser(UserHandle user) {
+            mUserHandle = user;
+            return this;
+        }
+
+        /**
+         * If this icon represents an instant app
+         */
+        public IconOptions setInstantApp(boolean instantApp) {
+            mIsInstantApp = instantApp;
+            return this;
+        }
+    }
+
     /**
      * An extension of {@link BitmapDrawable} which returns the bitmap pixel size as intrinsic size.
      * This allows the badging to be done based on the action bitmap size rather than
@@ -482,6 +687,37 @@ public class BaseIconFactory implements AutoCloseable {
         @Override
         public int getIntrinsicWidth() {
             return getBitmap().getWidth();
+        }
+    }
+
+    private static class NoopDrawable extends ColorDrawable {
+        @Override
+        public int getIntrinsicHeight() {
+            return 1;
+        }
+
+        @Override
+        public int getIntrinsicWidth() {
+            return 1;
+        }
+    }
+
+    private static class ClippedMonoDrawable extends InsetDrawable {
+
+        private final AdaptiveIconDrawable mCrop;
+
+        public ClippedMonoDrawable(Drawable base) {
+            super(base, -getExtraInsetFraction());
+            mCrop = new AdaptiveIconDrawable(new ColorDrawable(Color.BLACK), null);
+        }
+
+        @Override
+        public void draw(Canvas canvas) {
+            mCrop.setBounds(getBounds());
+            int saveCount = canvas.save();
+            canvas.clipPath(mCrop.getIconMask());
+            super.draw(canvas);
+            canvas.restoreToCount(saveCount);
         }
     }
 }

--- a/iconloaderlib/src/com/android/launcher3/icons/ClockDrawableWrapper.java
+++ b/iconloaderlib/src/com/android/launcher3/icons/ClockDrawableWrapper.java
@@ -232,6 +232,17 @@ public class ClockDrawableWrapper extends CustomAdaptiveIconDrawable implements 
     }
 
     @Override
+    public BitmapInfo getExtendedInfo(Bitmap bitmap , int color , BaseIconFactory iconFactory , float normalizationScale) {
+        AdaptiveIconDrawable background = new CustomAdaptiveIconDrawable(
+            getBackground().getConstantState().newDrawable(), null);
+        BitmapInfo bitmapInfo = iconFactory.createBadgedIconBitmap(background,
+            Process.myUserHandle(), mTargetSdkVersion, false);
+
+        return new ClockBitmapInfo(bitmap, color, normalizationScale,
+            mAnimationInfo, bitmapInfo.icon, mThemeData);
+    }
+
+    @Override
     public void drawForPersistence(Canvas canvas) {
         LayerDrawable foreground = (LayerDrawable) getForeground();
         resetLevel(foreground, mAnimationInfo.hourLayerIndex);

--- a/iconloaderlib/src/com/android/launcher3/icons/IconProvider.java
+++ b/iconloaderlib/src/com/android/launcher3/icons/IconProvider.java
@@ -48,6 +48,7 @@ import androidx.annotation.ArrayRes;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.os.BuildCompat;
 
 import com.android.launcher3.icons.ThemedIconDrawable.ThemeData;
 import com.android.launcher3.util.SafeCloseable;
@@ -63,7 +64,7 @@ import java.util.function.Supplier;
 
 import app.lawnchair.icons.CustomAdaptiveIconDrawable;
 
-/**
+@BuildCompat.PrereleaseSdkCheck /**
  * Class to handle icon loading from different packages
  */
 public class IconProvider {
@@ -76,6 +77,8 @@ public class IconProvider {
     protected static final String ATTR_PACKAGE = "package";
     protected static final String ATTR_COMPONENT = "component";
     protected static final String ATTR_DRAWABLE = "drawable";
+
+    public static final boolean ATLEAST_T = BuildCompat.isAtLeastT();
 
     private static final String TAG = "IconProvider";
     private static final boolean DEBUG = false;

--- a/iconloaderlib/src/com/android/launcher3/icons/ThemedIconDrawable.java
+++ b/iconloaderlib/src/com/android/launcher3/icons/ThemedIconDrawable.java
@@ -293,6 +293,11 @@ public class ThemedIconDrawable extends FastBitmapDrawable {
         }
 
         @Override
+        public BitmapInfo getExtendedInfo(Bitmap bitmap , int color , BaseIconFactory iconFactory , float normalizationScale) {
+            return new ThemedBitmapInfo(bitmap, color, mThemeData, normalizationScale, bitmap);
+        }
+
+        @Override
         public void drawForPersistence(Canvas canvas) {
             draw(canvas);
         }
@@ -322,6 +327,11 @@ public class ThemedIconDrawable extends FastBitmapDrawable {
             Bitmap userBadge = Process.myUserHandle().equals(user)
                     ? null : iconFactory.getUserBadgeBitmap(user);
             return new ThemedBitmapInfo(bitmap, color, mThemeData, normalizationScale, userBadge);
+        }
+
+        @Override
+        public BitmapInfo getExtendedInfo(Bitmap bitmap , int color , BaseIconFactory iconFactory , float normalizationScale) {
+            return new ThemedBitmapInfo(bitmap, color, mThemeData, normalizationScale, bitmap);
         }
 
         @Override

--- a/iconloaderlib/src/com/android/launcher3/util/FlagOp.java
+++ b/iconloaderlib/src/com/android/launcher3/util/FlagOp.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (C) 2022 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.android.launcher3.util;
+
+/**
+ * Utility interface for representing flag operations
+ */
+public interface FlagOp {
+
+    FlagOp NO_OP = i -> i;
+
+    int apply(int flags);
+
+    /**
+     * Returns a new OP which adds the provided flag after applying all previous operations
+     */
+    static FlagOp addFlag(int flag) {
+        return i -> i | flag;
+    }
+
+    /**
+     * Returns a new OP which removes the provided flag after applying all previous operations
+     */
+    static FlagOp removeFlag(int flag) {
+        return i -> i & ~flag;
+    }
+
+    /**
+     * Returns a new OP which adds or removed the provided flag based on {@code enable} after
+     * applying all previous operations
+     */
+    default FlagOp setFlag(int flag, boolean enable) {
+        return enable ? addFlag(flag) : removeFlag(flag);
+    }
+}


### PR DESCRIPTION
* Add Support Gesture for A13 without dropping A12/A12L
* Add support Icon (TaskIconCache)

Bug :
* PIP
* Split Screen

Added : ISplitScreenExt for A13 there's a better way to hook onGoingToRecentsLegacy but since I'm lazy I'll leave it to you guys :) Maybe you can clean it up :)

Link https://github.com/LawnchairLauncher/lawnchair/pull/3159.