### PR TITLE
fix NoSuchMethodError on api 33 and below

### DIFF
--- a/iconloaderlib/src/com/android/launcher3/icons/cache/BaseIconCache.java
+++ b/iconloaderlib/src/com/android/launcher3/icons/cache/BaseIconCache.java
@@ -617,7 +617,7 @@ public abstract class BaseIconCache {
                     addIconToDB(values, cacheKey.componentName, info, getSerialNumberForUser(user),
                             info.lastUpdateTime);
 
-                } catch (NameNotFoundException e) {
+                } catch (NameNotFoundException | NoSuchMethodError e) {
                     if (DEBUG) Log.d(TAG, "Application not installed " + packageName);
                     entryUpdated = false;
                 }


### PR DESCRIPTION
This is related to `PackageInfoFlags` not available below 33

See: https://developer.android.com/reference/android/content/pm/PackageManager.PackageInfoFlags