### PR TITLE
fix: Add multi-user support to ComponentKey

### DIFF
--- a/iconloaderlib/src/com/android/launcher3/util/ComponentKey.java
+++ b/iconloaderlib/src/com/android/launcher3/util/ComponentKey.java
@@ -76,7 +76,7 @@ public class ComponentKey {
         }
         try {
             return new ComponentKey(componentName,
-                    UserHandle.getUserHandleForUid(Integer.parseInt(str.substring(sep + 1))));
+                    UserHandle.of(Integer.parseInt(str.substring(sep + 1))));
         } catch (NumberFormatException ex) {
             return null;
         }


### PR DESCRIPTION
<!-- 
  Thanks for your contribution! A clear description and a test plan are the best way to get your PR reviewed and merged quickly.
  For simple `Style` or `Chore` changes, a detailed description is optional.
-->

### Description

<!-- A clear and concise one-paragraph summary of what this PR does. -->

Fix `ComponentKey.fromString()` to correctly deserialize user identifiers for multi-user scenarios (cloned apps, work profiles). Replace `getUserHandleForUid()` (expects Linux UID) with `UserHandle.of()` (expects user identifier) to match what `toString()` writes.

Ref: LawnchairLauncher/lawnchair#6668

### Reasoning

<!-- 
  (Optional - for major changes)
  A more detailed explanation of the "why." 
  - Why was this change necessary? (e.g., technical debt, user feedback, architectural improvement)
  - What are the core principles of the new solution?
-->

`toString()` serializes the user as `user.hashCode()`, which returns the **user identifier** (0, 10, 11...). But `fromString()` deserializes with `getUserHandleForUid()`, which expects a **Linux UID** and divides by 100000. All user identifiers below 100000 collapse to user 0.

```
toString():   user 10 → hashCode() → 10 → stored as "#10"
fromString(): "#10" → getUserHandleForUid(10) → 10 / 100000 = 0 → user 0 ❌
fix:          "#10" → UserHandle.of(10) → user 10 ✅
```

This pair was introduced in AOSP commit [`4e5080a`](https://android.googlesource.com/platform/frameworks/libs/systemui/+/4e5080a). AOSP's own Launcher3 does **not** use `ComponentKey.fromString()` — it has a separate `parseComponentKey`/`encode` pair based on serial numbers (`PinnedAppsAdapter.java`). The bug has not surfaced in AOSP because the method is effectively unused there.

Lawnchair uses `fromString()` extensively (7 call sites) via Room TypeConverters and SharedPreferences for icon overrides, custom app names, and hidden apps — all break for non-primary users.

### Testing

<!-- 
  (Optional - but highly encouraged for any functional change)
  A step-by-step script for how to test these changes.
-->

1. Enable app cloning (vivo App Clone / Xiaomi Dual Apps / Work Profile)
2. Long-press cloned app → Customize → Change icon
3. Verify cloned app's icon changes (not the main app's)
4. Verify main app's icon is unaffected
5. Test custom app name on cloned app — should only affect the clone

### Type of change

<!-- Please replace the :x: with a :white_check_mark: for the ONE line that best describes your change. -->

:white_check_mark: **Bug fix** (A non-breaking change that fixes an issue)
:x: **New feature** (A non-breaking change that adds functionality)
:x: **Breaking change** (A fix or feature that would cause existing functionality to not work as expected)
:x: **Refactor** (A code change that neither fixes a bug nor adds a feature)
:x: **Performance** (A code change that improves performance)
:x: **Style** (Code style changes)
:x: **Docs** (Changes to documentation)
:x: **Chore** (Changes to the build process or other tooling)