### PR TITLE
refactor: Discourage the usage of prefsNoContext

### DIFF
--- a/iconloaderlib/src/app/lawnchair/icons/IconPreferences.kt
+++ b/iconloaderlib/src/app/lawnchair/icons/IconPreferences.kt
@@ -1,6 +1,5 @@
 package app.lawnchair.icons
 
-import android.app.ActivityThread
 import android.content.Context
 import android.content.SharedPreferences
 import android.content.pm.LauncherActivityInfo
@@ -25,17 +24,10 @@ fun Context.shouldShadowBGIcons(): Boolean = prefs.getBoolean("pref_shadowBGIcon
 fun Context.isThemedIconsEnabled(): Boolean = prefs.getBoolean("themed_icons", false)
 fun Context.shouldTintIconPackBackgrounds(): Boolean = prefs.getBoolean("tint_icon_pack_backgrounds", false)
 
-val prefsNoContext: SharedPreferences get() = ActivityThread.currentApplication()
-    .getSharedPreferences(SHARED_PREFERENCES_KEY, Context.MODE_PRIVATE)
+fun Context.shouldForceMonochrome(): Boolean = prefs.getBoolean("pref_forceIconMonochrome", false)
 
-fun shouldForceMonochrome(): Boolean {
-    val prefs = prefsNoContext
-
-    return prefs.getBoolean("pref_forceIconMonochrome", false)
-}
-
-private fun getCustomAppNameMap(): Map<ComponentKey, String> {
-    val prefs = prefsNoContext
+private fun getCustomAppNameMap(context: Context): Map<ComponentKey, String> {
+    val prefs = context.prefs
 
     val customLabel = prefs.getString("pref_appNameMap", "{}")
     if (customLabel.isNullOrEmpty()) return emptyMap()
@@ -51,9 +43,9 @@ private fun getCustomAppNameMap(): Map<ComponentKey, String> {
     return map
 }
 
-fun getCustomAppNameForComponent(info: LauncherActivityInfo): CharSequence? {
+fun getCustomAppNameForComponent(context: Context, info: LauncherActivityInfo): CharSequence? {
     val key = ComponentKey(info.componentName, info.user)
-    val customLabel = getCustomAppNameMap()[key]
+    val customLabel = getCustomAppNameMap(context)[key]
     if (!customLabel.isNullOrEmpty()) {
         return customLabel
     }

--- a/iconloaderlib/src/com/android/launcher3/icons/cache/LauncherActivityCachingLogic.kt
+++ b/iconloaderlib/src/com/android/launcher3/icons/cache/LauncherActivityCachingLogic.kt
@@ -16,9 +16,9 @@
 
 package com.android.launcher3.icons.cache
 
+import android.app.ActivityThread
 import android.content.ComponentName
 import android.content.Context
-import android.content.pm.ActivityInfo
 import android.content.pm.LauncherActivityInfo
 import android.os.Build
 import android.os.Build.VERSION
@@ -38,7 +38,7 @@ object LauncherActivityCachingLogic : CachingLogic<LauncherActivityInfo> {
 
     override fun getUser(info: LauncherActivityInfo): UserHandle = info.user
 
-    override fun getLabel(info: LauncherActivityInfo): CharSequence? = getCustomAppNameForComponent(info)
+    override fun getLabel(info: LauncherActivityInfo): CharSequence? = getCustomAppNameForComponent(ActivityThread.currentApplication().applicationContext, info)
 
     override fun getApplicationInfo(info: LauncherActivityInfo) = info.applicationInfo
 

--- a/iconloaderlib/src/com/android/launcher3/icons/mono/MonoIconThemeController.kt
+++ b/iconloaderlib/src/com/android/launcher3/icons/mono/MonoIconThemeController.kt
@@ -17,6 +17,7 @@
 package com.android.launcher3.icons.mono
 
 import android.annotation.TargetApi
+import android.app.ActivityThread
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Bitmap.Config.ALPHA_8
@@ -93,7 +94,7 @@ class MonoIconThemeController(
         if (mono != null) {
             return ClippedMonoDrawable(mono, shapePath)
         }
-        if (shouldForceMonochrome() && shouldForceThemeIcon && !isFileDrawable) {
+        if (ActivityThread.currentApplication().applicationContext.shouldForceMonochrome() && shouldForceThemeIcon && !isFileDrawable) {
             return MonochromeIconFactory(info.icon.width).wrap(base, shapePath)
         }
         return null


### PR DESCRIPTION
* Discoutinued the use of prefsNoContext (migration are below)
	* ReplaceWith("ActivityThread.currentApplication().applicationContext")
	* ReplaceWith("Context.prefs")