### PR TITLE
fix: Remove JvmRecord tag from BadgeDrawableInfo

### DIFF
--- a/iconloaderlib/src/com/android/launcher3/icons/BitmapInfo.kt
+++ b/iconloaderlib/src/com/android/launcher3/icons/BitmapInfo.kt
@@ -233,7 +233,7 @@ open class BitmapInfo(
      * @param drawableRes Drawable resource for the badge.
      * @param colorRes Color resource to tint the badge.
      */
-    @JvmRecord
+//    @JvmRecord LC-Note: May crash with NCDFE of BadgeDrawableInfo with r8 RecordTag as the reason
     data class BadgeDrawableInfo(
         @field:DrawableRes @param:DrawableRes val drawableRes: Int,
         @field:ColorRes @param:ColorRes val colorRes: Int


### PR DESCRIPTION
For some reason this tag make the app crash when trying to access Private Space with R8 RecordTag being the cause.