### PR TITLE
feat: transparent icon backgrounds for all icons

### DIFF
--- a/iconloaderlib/src/app/lawnchair/icons/IconPreferences.kt
+++ b/iconloaderlib/src/app/lawnchair/icons/IconPreferences.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.content.pm.LauncherActivityInfo
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import androidx.core.graphics.ColorUtils
@@ -54,6 +55,9 @@ fun getCustomAppNameForComponent(context: Context, info: LauncherActivityInfo): 
 
 
 fun getWrapperBackgroundColor(context: Context, icon: Drawable): Int {
+    if (context.shouldTransparentBGIcons()) {
+        return Color.TRANSPARENT
+    }
     val lightness = context.prefs.getFloat("pref_coloredBackgroundLightness", 1f)
     val palette = Palette.Builder(drawableToBitmap(icon)).generate()
     val dominantColor = palette.getDominantColor(DEFAULT_WRAPPER_BACKGROUND)

--- a/iconloaderlib/src/com/android/launcher3/icons/BaseIconFactory.java
+++ b/iconloaderlib/src/com/android/launcher3/icons/BaseIconFactory.java
@@ -491,8 +491,10 @@ public class BaseIconFactory implements AutoCloseable {
             Path shapePath = getShapePath(aid, icon.getBounds());
             int count = canvas.save();
             canvas.translate(offset, offset);
-            if (bitmapGenerationMode == MODE_WITH_SHADOW
-                    || bitmapGenerationMode == MODE_HARDWARE_WITH_SHADOW) {
+            // Lawnchair: skip shadow when transparent backgrounds are enabled.
+            boolean skipShadow = IconPreferencesKt.shouldTransparentBGIcons(mContext);
+            if (!skipShadow && (bitmapGenerationMode == MODE_WITH_SHADOW
+                    || bitmapGenerationMode == MODE_HARDWARE_WITH_SHADOW)) {
                 getShadowGenerator().addPathShadow(shapePath, canvas);
             }
 
@@ -534,7 +536,11 @@ public class BaseIconFactory implements AutoCloseable {
             icon.draw(canvas);
             canvas.restore();
 
-            if (bitmapGenerationMode == MODE_WITH_SHADOW && targetBitmap != null) {
+            if (bitmapGenerationMode == MODE_WITH_SHADOW && targetBitmap != null
+                    // Lawnchair: skip shadow on non-adaptive icons (e.g. icon pack icons)
+                    // when transparent backgrounds are enabled, as drawShadow creates
+                    // a white/gray glow on transparent/glass icons.
+                    && !IconPreferencesKt.shouldTransparentBGIcons(mContext)) {
                 // Shadow extraction only works in software mode
                 getShadowGenerator().drawShadow(targetBitmap, canvas);
 

--- a/iconloaderlib/src/com/android/launcher3/icons/IconProvider.java
+++ b/iconloaderlib/src/com/android/launcher3/icons/IconProvider.java
@@ -188,36 +188,9 @@ public class IconProvider {
     @Nullable
     protected Drawable loadPackageIcon(
             @NonNull PackageItemInfo info, @NonNull ApplicationInfo appInfo, int density) {
-        final PackageManager pm = mContext.getPackageManager();
-
-        // Lawnchair: First try loading via PackageManager APIs that Samsung
-        // intercepts for Theme Park / Good Lock icon theming.
-        // Samsung's SemApplicationPackageManager overrides getActivityIcon()
-        // and getApplicationIcon() to return themed icons.
         try {
-            Drawable systemIcon = null;
-
-            // For activities, try getActivityIcon first
-            if (info instanceof android.content.pm.ActivityInfo && info.name != null) {
-                ComponentName cn = new ComponentName(info.packageName, info.name);
-                systemIcon = pm.getActivityIcon(cn);
-            }
-
-            // Fallback to getApplicationIcon
-            if (systemIcon == null) {
-                systemIcon = pm.getApplicationIcon(info.packageName);
-            }
-
-            if (systemIcon != null
-                    && (Build.VERSION.SDK_INT < 30
-                        || !pm.isDefaultApplicationIcon(systemIcon))) {
-                return systemIcon;
-            }
-        } catch (Exception ignored) { }
-
-        // Fallback: load directly from app resources with specific density
-        try {
-            final Resources resources = pm.getResourcesForApplication(appInfo);
+            final Resources resources = mContext.getPackageManager()
+                    .getResourcesForApplication(appInfo);
             // Try to load the package item icon first
             if (info != appInfo && info.icon != 0) {
                 try {

--- a/iconloaderlib/src/com/android/launcher3/icons/IconProvider.java
+++ b/iconloaderlib/src/com/android/launcher3/icons/IconProvider.java
@@ -188,9 +188,36 @@ public class IconProvider {
     @Nullable
     protected Drawable loadPackageIcon(
             @NonNull PackageItemInfo info, @NonNull ApplicationInfo appInfo, int density) {
+        final PackageManager pm = mContext.getPackageManager();
+
+        // Lawnchair: First try loading via PackageManager APIs that Samsung
+        // intercepts for Theme Park / Good Lock icon theming.
+        // Samsung's SemApplicationPackageManager overrides getActivityIcon()
+        // and getApplicationIcon() to return themed icons.
         try {
-            final Resources resources = mContext.getPackageManager()
-                    .getResourcesForApplication(appInfo);
+            Drawable systemIcon = null;
+
+            // For activities, try getActivityIcon first
+            if (info instanceof android.content.pm.ActivityInfo && info.name != null) {
+                ComponentName cn = new ComponentName(info.packageName, info.name);
+                systemIcon = pm.getActivityIcon(cn);
+            }
+
+            // Fallback to getApplicationIcon
+            if (systemIcon == null) {
+                systemIcon = pm.getApplicationIcon(info.packageName);
+            }
+
+            if (systemIcon != null
+                    && (Build.VERSION.SDK_INT < 30
+                        || !pm.isDefaultApplicationIcon(systemIcon))) {
+                return systemIcon;
+            }
+        } catch (Exception ignored) { }
+
+        // Fallback: load directly from app resources with specific density
+        try {
+            final Resources resources = pm.getResourcesForApplication(appInfo);
             // Try to load the package item icon first
             if (info != appInfo && info.icon != 0) {
                 try {


### PR DESCRIPTION
## What

Makes the existing **transparent icon background** option actually remove the automatic white/light background behind *every* icon (previously it only affected themed / icon-pack icons), and improves theming integration.

## Changes
- **`IconPreferences.kt`** — `getWrapperBackgroundColor()` returns `Color.TRANSPARENT` when transparent icon backgrounds are enabled, so the white wrapper added around non-adaptive/legacy icons is removed.
- **`BaseIconFactory.java`** — skip shadow generation (`addPathShadow` for adaptive wrapping and `drawShadow` for non-adaptive / icon-pack icons) when transparent backgrounds are enabled, otherwise a white/gray glow appears on transparent/glass icons.
- **`IconProvider.java`** — load icons via `PackageManager.getActivityIcon()` / `getApplicationIcon()` first, so Samsung Theme Park / Good Lock themed icons (which Samsung serves by intercepting these APIs) are picked up; falls back to the previous resource-based loading.

## Notes
Submodule half of the LawnchairLauncher/lawnchair PR, which surfaces the toggle in General > Icons and bumps the submodule pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)