### PR TITLE
fix: restore Samsung Theme Park / Good Lock themed icons

### DIFF
--- a/iconloaderlib/src/com/android/launcher3/icons/IconProvider.java
+++ b/iconloaderlib/src/com/android/launcher3/icons/IconProvider.java
@@ -188,9 +188,36 @@ public class IconProvider {
     @Nullable
     protected Drawable loadPackageIcon(
             @NonNull PackageItemInfo info, @NonNull ApplicationInfo appInfo, int density) {
+        final PackageManager pm = mContext.getPackageManager();
+
+        // Lawnchair: First try loading via PackageManager APIs that Samsung
+        // intercepts for Theme Park / Good Lock icon theming.
+        // Samsung's SemApplicationPackageManager overrides getActivityIcon()
+        // and getApplicationIcon() to return themed icons.
         try {
-            final Resources resources = mContext.getPackageManager()
-                    .getResourcesForApplication(appInfo);
+            Drawable systemIcon = null;
+
+            // For activities, try getActivityIcon first
+            if (info instanceof android.content.pm.ActivityInfo && info.name != null) {
+                ComponentName cn = new ComponentName(info.packageName, info.name);
+                systemIcon = pm.getActivityIcon(cn);
+            }
+
+            // Fallback to getApplicationIcon
+            if (systemIcon == null) {
+                systemIcon = pm.getApplicationIcon(info.packageName);
+            }
+
+            if (systemIcon != null
+                    && (Build.VERSION.SDK_INT < 30
+                        || !pm.isDefaultApplicationIcon(systemIcon))) {
+                return systemIcon;
+            }
+        } catch (Exception ignored) { }
+
+        // Fallback: load directly from app resources with specific density
+        try {
+            final Resources resources = pm.getResourcesForApplication(appInfo);
             // Try to load the package item icon first
             if (info != appInfo && info.icon != 0) {
                 try {


### PR DESCRIPTION
## Summary
Restores Samsung **Theme Park / Good Lock** themed app icons, which regressed in Lawnchair 16.

## Regression
`loadPackageIcon` loads app icons straight from the app's resources via `getResourcesForApplication()`, which bypasses Samsung's framework theming — `SemApplicationPackageManager` intercepts `getActivityIcon()` / `getApplicationIcon()` to return Theme Park / Good Lock themed icons.

This regressed in **`4767f8b` ("Merge tag 'android-16.0.0_r2' into 15-dev")**: before that merge, app icons fell back to `ActivityInfo.loadIcon(PackageManager)` (which Samsung themes); the Android 16 launcher3 rework replaced that path with the resource-based `loadPackageIcon()`. As a result, themed icons that rendered in Lawnchair 15 stopped appearing in 16-dev.

Verified across the file history: at `4767f8b` the `ActivityInfo.loadIcon(pm)` fallback was removed and `loadPackageIcon()` (resource-based) introduced; the commit is in `16-dev` but not in the v15 line.

## Fix
Try the PackageManager icon APIs first (`getActivityIcon`, then `getApplicationIcon`), falling back to the existing resource-based path when the system returns the default icon (`isDefaultApplicationIcon`) or the lookup throws.

## Demo (before / after)
Same Samsung device, same Theme Park theme, icon source kept on **System** the whole time — only the build differs.

**Samsung themed icons (this PR)** — compare **Lawnchair (NoFix)** vs the **fixed build**:

| Build | Samsung themed icons |
|---|---|
| Lawnchair 15 (official) | ✅ |
| 16-dev **without** this fix (NoFix) | ❌ default icons |
| 16-dev **with** this fix | ✅ restored |

**Also visible in the same clip — transparent icon backgrounds (LawnchairLauncher/lawnchair#6890)** — compare **Lawnchair 15** vs the **fixed build**: v15 still draws the automatic white plate behind transparent / themed icons, the fixed build removes it. (Separate PR; shown here only because it's the same recording.)

Since the icon source never leaves **System**, both differences come from the code, not from a user setting.

▶️ _video below_
https://github.com/user-attachments/assets/91d138ce-72cf-4775-9fe2-f03f685d6dbe

## Notes
Split out of #30 to keep it atomic — that PR keeps the transparent-icon-background changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
