### PR TITLE
fix: Resolve themed icon colors through COLORS_LOADER

### DIFF
--- a/iconloaderlib/src/com/android/launcher3/icons/mono/ThemedIconDrawable.kt
+++ b/iconloaderlib/src/com/android/launcher3/icons/mono/ThemedIconDrawable.kt
@@ -89,23 +89,24 @@ class ThemedIconDrawable(constantState: ThemedConstantState) :
         /** Get an int array representing background and foreground colors for themed icons */
         @JvmStatic
         fun getColors(context: Context): IntArray {
-            if (context.shouldTransparentBGIcons()) {
-                return intArrayOf(
-                    Color.TRANSPARENT,
-                    context.resources.getColor(R.color.themed_icon_color),
-                )
+            // Always resolve through COLORS_LOADER so the host app's theme (which may follow an
+            // in-app preference rather than the system night mode) decides the colors. Transparent
+            // backgrounds only drop the background color; the foreground still comes from the host.
+            val colors = COLORS_LOADER(context)
+            return if (context.shouldTransparentBGIcons()) {
+                intArrayOf(Color.TRANSPARENT, colors[1])
+            } else {
+                colors
             }
-            if (COLORS_LOADER != null) {
-                return COLORS_LOADER(context);
-            }
+        }
+
+        @JvmStatic
+        var COLORS_LOADER: (Context) -> IntArray = { context ->
             val res = context.resources
-            return intArrayOf(
+            intArrayOf(
                 res.getColor(R.color.themed_icon_background_color),
                 res.getColor(R.color.themed_icon_color),
             )
         }
-
-        @JvmStatic
-        var COLORS_LOADER: (Context) -> IntArray = { context -> getColors(context) }
     }
 }


### PR DESCRIPTION
Experienced an annoying bug - with themed icons in darkmode with transparent background settings configured, the launcher drawer background color, icon colors, and app folder colors were inverting, and often flipping back and forth from correctly set theme to the light theme. That fix is [here](https://github.com/LawnchairLauncher/lawnchair/pull/7267) but requires this change as well.

Root cause:
getColors() early-returned `R.color.themed_icon_color` when transparent backgrounds were enabled. That resource lives in values-night, so it follows the system night mode and bypasses COLORS_LOADER entirely, ignoring a host app that themes from its own preference instead. This regressed in [feat: Reimplement transparent icons (#28)](https://github.com/LawnchairLauncher/platform_frameworks_libs_systemui/pull/28); the code it replaced routed through getColors() correctly.

Fix:
Always resolve through COLORS_LOADER, and let a transparent background drop only the background colour while the foreground still comes from the host.